### PR TITLE
Theme setup

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -4,6 +4,11 @@ if ( ! defined( 'UTKCHANCELLOR_VERSION' ) ) {
 	define( 'UTKCHANCELLOR_VERSION', '0.1.2' );
 }
 
+// Add full-width to blocks – this is now added in the theme.json as "layout" and is not needed here
+// function setup_theme() {
+// 	add_theme_support( 'align-wide' );
+//   }
+
  // Get the stylesheet
  function mychildtheme_enqueue_styles() {
 	wp_enqueue_style( 'utkchancellor-style', get_template_directory_uri() . '/style.css', array(), UTKCHANCELLOR_VERSION, true );

--- a/src/scss/_custom_variables.scss
+++ b/src/scss/_custom_variables.scss
@@ -325,7 +325,8 @@ $font-family-code: var(--#{$variable-prefix}font-monospace) !default;
 $font-family-sans-serif: "Gotham A", "Gotham B", "Gotham SSm 4r", "Gotham SSm A",
   "Gotham SSm B", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $font-size-base: 1.25rem; // Assumes the browser default, typically `16px`
-$font-size-lg: $font-size-base * 1.25 !default;
+$font-size-lg: $font-size-base * 1.1;
+$font-size-xlg: $font-size-base * 1.25;
 $font-size-sm: $font-size-base * 0.875 !default;
 
 $font-weight-lighter: lighter !default;
@@ -338,17 +339,17 @@ $font-weight-ultra: 900;
 $font-weight-base: $font-weight-normal !default;
 $line-height-base: 1.5 !default;
 
-$h1-font-size: $font-size-base * 5.2; // 6.6rem
-$h2-font-size: $font-size-base * 3.2; // 4rem
-$h3-font-size: $font-size-base * 2.24; // 2.8rem
-$h4-font-size: $font-size-base * 1.6; // 2rem
-$h5-font-size: $font-size-base * 1.248; // 1.56rem
-$h6-font-size: $font-size-base; // 1.25rem
+$h1-font-size: clamp((calc($font-size-base * 2.24)), 11.5vw, (calc($font-size-base * 3.7224))); //max size is 4.653rem min-size 2.8rem
+$h2-font-size: clamp((calc($font-size-base * 1.647)), 8.4558vw, (calc($font-size-base * 2.7368))); // max size is 3.421rem
+$h3-font-size: clamp((calc($font-size-base * 1.211)), 6.2175vw, (calc($font-size-base * 2.012))); // max size is 2.515rem
+$h4-font-size: clamp((calc($font-size-base * 1)), 4.572vw, (calc($font-size-base *  1.48))); // max size is  1.85rem
+$h5-font-size: clamp((calc($font-size-base * .9)), 3.362vw, (calc($font-size-base *  1.088))); // max size is  1.36rem
+$h6-font-size: clamp((calc($font-size-base * .8)), 2.661vw, (calc($font-size-base *  0.8))); // max size is  1rem
 
 $headings-margin-bottom: calc($spacer / 2) !default;
 $headings-font-family: null !default;
-$headings-font-weight: 700;
-$headings-line-height: .97;
+$headings-font-weight: $font-weight-bolder;
+$headings-line-height: .85;
 $headings-color: null !default;
 
 $display-font-sizes: (
@@ -363,14 +364,11 @@ $display-font-sizes: (
 $display-font-weight: 900 !default;
 $display-line-height: 1 !default;
 
-$lead-font-size: $font-size-base * 1.25 !default;
-$lead-font-weight: 200 !default;
-
 $hr-border-color: rgba($utsmokey, 0.25) !default;
 
 // scss-docs-start type-variables
-$lead-font-size: $font-size-base * 1.25 !default;
-$lead-font-weight: 700;
+$lead-font-size: clamp((calc($font-size-base * 1)), 4.572vw, (calc($font-size-base *  1.48))); // max size is  1.85rem
+$lead-font-weight: $font-weight-light;
 
 $small-font-size: 0.875em !default;
 

--- a/src/scss/_extend.scss
+++ b/src/scss/_extend.scss
@@ -12,13 +12,13 @@
 }
 
 .title-area {
-  border: 1px solid red;
+  // border: 1px solid red;
 }
 
 .universal-navigation {
-  border: 2px solid green;
+  // border: 2px solid green;
 }
-
+// the layout property adds a class that does this
 // .site-inner > * {
 //   max-width: 80vw;
 //   margin-left: 10vw;
@@ -28,11 +28,12 @@
 .alignfull {
   width: 100vw;
   max-width: 100vw;
-  border: 5px solid pink;
   margin: 32px calc(50% - 50vw);
+  display: block;
+  position: relative;
 }
 
-// .alignwide {
-//   margin-left: -80px;
-//   margin-right: -80px;
-// }
+.alignwide {
+  margin-left: -80px;
+  margin-right: -80px;
+}

--- a/src/scss/_extend.scss
+++ b/src/scss/_extend.scss
@@ -1,0 +1,38 @@
+@import 'custom_variables';
+@import './node_modules/bootstrap/scss/variables';
+
+/* Site Inner
+--------------------------------------------- */
+
+.site-inner {
+  clear: both;
+  margin: 0 auto;
+  //   padding: 60px 30px 0;
+  //   border: 2px solid red;
+}
+
+.title-area {
+  border: 1px solid red;
+}
+
+.universal-navigation {
+  border: 2px solid green;
+}
+
+// .site-inner > * {
+//   max-width: 80vw;
+//   margin-left: 10vw;
+//   margin-right: 10vw;
+// }
+
+.alignfull {
+  width: 100vw;
+  max-width: 100vw;
+  border: 5px solid pink;
+  margin: 32px calc(50% - 50vw);
+}
+
+// .alignwide {
+//   margin-left: -80px;
+//   margin-right: -80px;
+// }

--- a/src/scss/components/_cover.scss
+++ b/src/scss/components/_cover.scss
@@ -1,4 +1,4 @@
 .wp-block-cover {
-  width: 100vw;
-  border: 6px solid purple !important;
+  width: 100%;
+  position: relative;
 }

--- a/src/scss/components/_cover.scss
+++ b/src/scss/components/_cover.scss
@@ -1,0 +1,4 @@
+.wp-block-cover {
+  width: 100vw;
+  border: 6px solid purple !important;
+}

--- a/src/scss/styles/_typography.scss
+++ b/src/scss/styles/_typography.scss
@@ -54,12 +54,12 @@ h1,
 }
 
 h1 {
-  margin-top: calc($spacer * 6);
+  // margin-top: calc($spacer * 6);
   margin-bottom: calc($spacer * 2);
-  font-weight: 900; // think it needs to be heavier like this here
+  text-transform: uppercase;
 }
 h2 {
-  margin-top: calc($spacer * 5);
+  margin-top: calc($spacer * 3.2);
   margin-bottom: calc($spacer * 2.2);
 }
 
@@ -105,4 +105,7 @@ h2.heading-oa-bar {
   width: auto;
   position: relative;
   width: fit-content;
+}
+.lead strong {
+  font-weight: $font-weight-bold;
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -81,6 +81,7 @@ Template: genesis
 @import 'scss/components/accordion_folds';
 @import 'scss/components/calendars';
 @import 'scss/components/cards';
+@import 'scss/components/cover';
 @import 'scss/components/forms';
 // @import "scss/components/gallery";
 // @import "scss/components/latest_posts";
@@ -107,3 +108,5 @@ Template: genesis
 @import 'scss/styles/pagination';
 @import 'scss/styles/logos';
 @import 'scss/styles/wp';
+
+@import 'scss/extend';

--- a/src/theme.json
+++ b/src/theme.json
@@ -3,14 +3,36 @@
   "version": 2,
   "settings": {
     "blocks": {
+      "core/navigation": {
+        "elements": {
+          "link": {
+            "typography": {
+              "text-decoration": "underline"
+            }
+          }
+        }
+      },
       "core/button": {
         "color": {
           "background": "var(--wp--preset--color--smokey)",
           "text": "var(--wp--preset--color--white)"
         }
+      },
+      "core/heading": {
+        "color": {
+          "palette": [
+            {
+              "slug": "smokeyX",
+              "color": "#333333",
+              "name": "Web SmokeyX"
+            }
+          ]
+        }
       }
     },
     "color": {
+      "custom": false,
+      "defaultPalette": false,
       "palette": [
         {
           "slug": "orange",
@@ -21,6 +43,11 @@
           "slug": "smokey",
           "color": "#4b4b4b",
           "name": "Web Smokey"
+        },
+        {
+          "slug": "smokeyX",
+          "color": "#333333",
+          "name": "Web SmokeyX"
         },
         {
           "slug": "light",
@@ -40,8 +67,8 @@
       ]
     },
     "layout": {
-      "contentSize": "800px",
-      "wideSize": "1000px"
+      "contentSize": "900px",
+      "wideSize": "80vw"
     },
     "typography": {
       "fontFamilies": [
@@ -59,8 +86,14 @@
         "color": {
           "background": "var(--wp--preset--color--smokey)",
           "text": "var(--wp--preset--color--white)"
+        },
+        "border": {
+          "radius": ".45rem",
+          "width": ".2rem",
+          "color": "var(--wp--preset--color--orange)"
         }
-      }
+      },
+      "core/cover": {}
     },
     "typography": {
       "fontFamily": "var(--wp--preset--font-family--helvetica-arial)",


### PR DESCRIPTION
theme.json
- add color control. removing default palette. experiment with locking down colors of heading.
- add layout control.this command initiaes the new wide and full width options in wordpress. sets the default width and wide width (full width is controled by .alignfull which I added to a new extend.scss for now)

cover.scss
- add new controls for cover block. Trying to get the cover block to align full width. At the moment will only go full width when nested in a group block set to full width. the width:100% in this default class is breaking it. (Not fixed yet)

typography.scss and custom_variables.scss
- starting to add the new type scale to align with WDS

style.scss
- adding extend and cover as local imports