### PR TITLE
Responsive Pass 01

### DIFF
--- a/src/scss/_custom_variables.scss
+++ b/src/scss/_custom_variables.scss
@@ -326,7 +326,7 @@ $font-family-sans-serif: "Gotham A", "Gotham B", "Gotham SSm 4r", "Gotham SSm A"
   "Gotham SSm B", "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $font-size-base: 1.25rem; // Assumes the browser default, typically `16px`
 
-$font-size-base: 1.1rem; // Assumes the browser default, typically `16px`
+$font-size-base: 1.1rem; // This is setting base font to 17.6px 
 $font-size-lg: $font-size-base * 1.1;
 $font-size-xlg: $font-size-base * 1.25;
 $font-size-sm: $font-size-base * 0.875 !default;
@@ -1007,17 +1007,12 @@ $modal-content-bg:                  $white !default;
 $modal-content-color:               null !default;
 $modal-content-box-shadow-xs:       $box-shadow-sm !default;
 
-
 $modal-footer-margin-between:       .5rem !default;
 
 $modal-dialog-margin:               .5rem !default;
 $modal-dialog-margin-y-sm-up:       1.75rem !default;
 $modal-backdrop-bg:                 $black !default;
 $modal-backdrop-opacity:            .5 !default;
-
-
-
-
 
 $modal-content-border-width:        $border-width !default;
 
@@ -1026,11 +1021,7 @@ $modal-content-border-radius:       $border-radius-lg !default;
 $modal-content-inner-border-radius: subtract($modal-content-border-radius, $modal-content-border-width) !default;
 
 $modal-content-box-shadow-sm-up:    $box-shadow !default;
-
-
 // scss-docs-end modal-variables
-
-
 
 // Offcanvas
 

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -252,6 +252,10 @@
 }
 .profileCard {
   @extend .clipCorner-br-container-sm;
+  flex-direction: column;
+  @media screen and (min-width: 550px) {
+    flex-direction: row;
+  }
 }
 .bioCard {
   @extend .clipCorner-br-container;

--- a/src/scss/components/_latest_posts.scss
+++ b/src/scss/components/_latest_posts.scss
@@ -546,9 +546,21 @@ ul.chancellorThoughtPost {
     //   margin: 3rem 0 2rem 0;
     // }
 
+    // &:before {
+    // using arrow made from squares – rocky top arrow. Not used for now.
+    //   content: url('https://images.utk.edu/wds/rocky-top-arrow-02.svg');
+    //   transform: scale(0.3);
+    //   font-size: var(--wp--custom--typography--tiny);
+    //   transform-origin: calc($spacer * 4.75) center;
+    //   position: absolute;
+    //   bottom: calc($spacer * 0.25);
+    //   display: block;
+    //   width: 100%;
+    //   left: 0;
+    // }
     &:before {
-      content: url('https://images.utk.edu/wds/rocky-top-arrow-02.svg');
-      transform: scale(0.3);
+      content: url('https://images.utk.edu/wds/solid-arrow-03.svg');
+      transform: scale(0.4);
       font-size: var(--wp--custom--typography--tiny);
       transform-origin: calc($spacer * 4.75) center;
       position: absolute;

--- a/src/scss/regions/_navigation_horizontal_dropdown.scss
+++ b/src/scss/regions/_navigation_horizontal_dropdown.scss
@@ -251,7 +251,7 @@ nav.nav-primary {
 }
 
 li.current-menu-item > a {
-  background: $utgray2;
+  background-color: $utgray2 !important;
   box-shadow: inset 0px -2px $utorange;
   font-weight: bold;
   color: 'var(--wp--preset--color--smokeyX)' !important;

--- a/src/scss/styles/_blockquote.scss
+++ b/src/scss/styles/_blockquote.scss
@@ -109,14 +109,14 @@
       padding-left: calc($spacer * 2);
       padding: $spacer calc($spacer * 3);
       font-size: calc($p-font-size * 2);
-      line-height: calc($line-height-base * 0.8);
+      // line-height: calc($line-height-base * 0.8);
+      line-height: calc($line-height-base * 1);
     }
 
     &:before {
       left: calc($spacer * -0.9);
       bottom: calc($spacer * -0.25);
       font-size: calc($h1-font-size * 1.6);
-
       line-height: calc($line-height-base * 1.2);
       margin: 0;
       padding: 0;
@@ -130,8 +130,8 @@
       left: calc($spacer * -0.9);
       bottom: calc($spacer * -0.25);
       font-size: calc($h1-font-size * 1.6);
-
-      line-height: calc($line-height-base * 1.2);
+      // line-height: calc($line-height-base * 1.2);
+      line-height: calc($line-height-base * 1);
       margin: 0;
       padding: 0;
     }

--- a/src/scss/styles/_typography.scss
+++ b/src/scss/styles/_typography.scss
@@ -59,12 +59,11 @@ h1 {
   margin-bottom: calc($spacer * 3);
   text-transform: uppercase;
   // keeps super long words like chancellorship from breaking lines
-  inline-size: min-content;
+  // inline-size: min-content;
   word-break: normal;
   // max-width: 90vw;
   // @media screen and (min-width: 1200px) {
   //   max-width: 34vw;
-
   // }
 }
 h2 {
@@ -139,4 +138,24 @@ p.has-medium-font-size {
 
 .titleWidthFix {
   max-width: none !important;
+}
+
+// adding special case for h1 that appear inside columns. clamp is based off body width
+// must account for the container being a different width so VAL must be adjusted for scaling
+// to take place inside containers. Otherwise words break oddly.
+
+.wp-block-columns h1 {
+  font-size: clamp(
+    (calc($font-size-base * 2.24)),
+    3vw + 1rem,
+    (calc($font-size-base * 3.7224))
+  );
+}
+
+.wp-block-columns h2 {
+  font-size: clamp(
+    (calc($font-size-base * 1.647)),
+    2vw + 1rem,
+    (calc($font-size-base * 2.7368))
+  );
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -4,7 +4,7 @@ Theme URI: http://chancellor.utk.edu/
 Author: The UT Web Team
 Author URI: http://communications.utk.edu
 Description: The official UT WordPress Design System theme.
-Version: 0.1.6
+Version: 0.1.7
 
 Template: genesis
 

--- a/src/theme.json
+++ b/src/theme.json
@@ -199,33 +199,53 @@
         {
           "name": "Tiny",
           "slug": "tiny",
-          "size": "var(--wp--custom--typography--tiny)"
+          "size": "var(--wp--custom--typography--tiny)",
+          "fluid": {
+            "min": "calc(var(--wp--custom--typography--scale) * .5)",
+            "max": "calc(var(--wp--custom--typography--scale) * .68)"
+          }
         },
         {
           "name": "Small",
           "slug": "small",
-          "size": "var(--wp--custom--typography--small)"
+          "size": "var(--wp--custom--typography--small)",
+          "fluid": {
+            "min": "calc(var(--wp--custom--typography--scale) * .68)",
+            "max": "calc(var(--wp--custom--typography--scale) * .92)"
+          }
         },
         {
           "name": "Normal",
           "slug": "normal",
-          "size": "var(--wp--custom--typography--normal)"
+          "size": "var(--wp--custom--typography--normal)",
+          "fluid": {
+            "min": "calc(var(--wp--custom--typography--scale) * .92)",
+            "max": "var(--wp--custom--typography--scale"
+          }
         },
 
         {
           "name": "Medium",
+          "slug": "medium",
           "size": "var(--wp--custom--typography--medium)",
-          "slug": "medium"
+          "fluid": {
+            "min": "var(--wp--custom--typography--scale",
+            "max": "calc(var(--wp--custom--typography--scale) * 1.7)"
+          }
         },
         {
           "name": "Large",
+          "slug": "large",
           "size": "var(--wp--custom--typography--large)",
-          "slug": "large"
+          "fluid": {
+            "min": "calc(var(--wp--custom--typography--scale) * 1.7)",
+            "max": "calc(var(--wp--custom--typography--scale) * 2.32)"
+          }
         },
         {
           "name": "X-Large",
-          "size": "var(--wp--custom--typography--xlarge)",
           "slug": "x-large",
+          "size": "var(--wp--custom--typography--xlarge)",
           "fluid": {
             "min": "calc(var(--wp--custom--typography--scale) * 2.32)",
             "max": "calc(var(--wp--custom--typography--scale) * 3.16)"
@@ -235,7 +255,7 @@
     },
     "custom": {
       "typography": {
-        "scale": "1.25rem",
+        "scale": "1.1rem",
         "tiny": "calc(var(--wp--custom--typography--scale) * .68)",
         "small": "calc(var(--wp--custom--typography--scale) * .92)",
         "normal": "var(--wp--custom--typography--scale)",


### PR DESCRIPTION
– fix profileCard to be stacked on smallest screens. Fixes odd spacing between the content groups
– update style version number
– fix h1 and h2 scale issues due to clamp and container column issue (not scaling fast enough due to clamp looks at body view width not parent container. Had to scale VAL)
– update base font size in custom_variables and theme.json
– hero block quote and thoughtHero block quote line-height adjustment to align spacing
– change latest post thought card arrow graphic to solid arrow
– add fluid values to theme.json custom fonts (min size is the value of the next smaller down max)
– make current-menu-item background show on child list in full width