### PR TITLE
Responsive 02 

### DIFF
--- a/src/scss/_custom_variables.scss
+++ b/src/scss/_custom_variables.scss
@@ -1014,7 +1014,7 @@ $modal-dialog-margin-y-sm-up:       1.75rem !default;
 $modal-backdrop-bg:                 $black !default;
 $modal-backdrop-opacity:            .5 !default;
 
-$modal-content-border-width:        $border-width !default;
+$modal-content-border-width:        0;
 
 $modal-header-border-width:         $modal-content-border-width !default;
 $modal-content-border-radius:       $border-radius-lg !default;
@@ -1032,7 +1032,7 @@ $offcanvas-horizontal-width:        80vw;
 $offcanvas-vertical-height:         30vh !default;
 $offcanvas-transition-duration:     .3s !default;
 $offcanvas-title-line-height:       $modal-title-line-height !default;
-$offcanvas-bg-color:                purple;
+$offcanvas-bg-color:                white;
 // $offcanvas-color:                   $modal-content-color !default;
 // $offcanvas-box-shadow:              $modal-content-box-shadow-xs !default;
 // $offcanvas-backdrop-bg:             $modal-backdrop-bg !default;

--- a/src/scss/_extend.scss
+++ b/src/scss/_extend.scss
@@ -358,6 +358,7 @@ h1.adaOrange {
 .fancyLinkGroup {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: calc($spacer * 3);
   margin-bottom: $spacer;
 }

--- a/src/scss/regions/_navigation_horizontal_dropdown.scss
+++ b/src/scss/regions/_navigation_horizontal_dropdown.scss
@@ -67,7 +67,7 @@ nav.nav-primary {
   width: 100vw;
   margin-bottom: calc($spacer);
   // height: 100%;
-  padding-top: calc($spacer * 3);
+  // padding-top: calc($spacer * 3);
   // align-items: stretch;
 
   margin-left: calc($spacer / 2);
@@ -125,7 +125,9 @@ nav.nav-primary {
       }
 
       a {
-        padding: $spacer;
+        // controls the height and width of the nav buttons
+        padding: calc($spacer * 0.65);
+        min-width: 0;
         width: 100%;
         // height: auto;
         height: 100%; // makes menu-items stay same height even when more than one line
@@ -135,6 +137,7 @@ nav.nav-primary {
         display: block;
 
         @include media-breakpoint-up(lg) {
+          padding: $spacer;
           flex: 0 1 auto;
           // text-align: center;
           // border: 1px solid green;
@@ -190,11 +193,13 @@ nav.nav-primary {
         // background-color: greenyellow;
         height: auto;
         // margin: 0 -1rem -1rem -1rem;
-        margin: 0 0 0 calc($spacer * 0.75);
+        margin: 0 0 0 calc($spacer * 1.3);
         width: calc(100% - 2rem);
         // margin-bottom: -1rem;
         border-bottom: 2px solid $utgray1;
-        padding: calc($spacer * 0.5) 0;
+        // padding: calc($spacer * 0.5) 0;
+        padding: 0 0 calc($spacer * 0.5) 0;
+        padding: 0;
         z-index: 10;
         list-style: none;
         position: relative;
@@ -209,7 +214,7 @@ nav.nav-primary {
           margin-top: -300rem; // just pushing content off screen so doesn't mess with height of parent
           visibility: hidden;
           padding: 0 0;
-          min-width: 130%;
+          min-width: 110%;
           // when nav is next to grey items, it blends too much. Just adding a white border to pop a bit
           border-bottom: 1px solid white;
           border-left: 1px solid white;
@@ -219,9 +224,11 @@ nav.nav-primary {
           display: flex;
           flex-direction: row;
 
+          padding: calc($spacer * 0.45);
           @include media-breakpoint-up(lg) {
             background-color: $utgray1;
             min-width: 0;
+            padding: calc($spacer);
           }
           // border: 1px solid yellowgreen;
           // &:before {

--- a/src/scss/styles/_typography.scss
+++ b/src/scss/styles/_typography.scss
@@ -117,21 +117,6 @@ h2.heading-oa-bar {
   font-weight: $font-weight-bold;
 }
 
-.quietHeading {
-  font-size: 80%;
-  line-height: 120%;
-  text-transform: uppercase;
-  letter-spacing: 0.5vw;
-  margin-bottom: 1.7vw;
-}
-
-h3.quietHeading {
-  text-transform: uppercase;
-  font-size: $h6-font-size;
-  margin-top: calc($spacer * 2.25);
-  font-weight: $font-weight-normal;
-}
-
 p.has-medium-font-size {
   margin-bottom: calc($spacer * 2);
 }
@@ -158,4 +143,24 @@ p.has-medium-font-size {
     2vw + 1rem,
     (calc($font-size-base * 2.7368))
   );
+}
+
+// special small headings used on the Chancellor site. Forcing font size smaller
+// percentage was being overwritten by block-column fix above
+h1.quietHeading,
+h2.quietHeading {
+  // font-size: 80%;
+  font-size: var(--wp--custom--typography--small);
+  line-height: 120%;
+  text-transform: uppercase;
+  letter-spacing: 0.5vw;
+  margin-bottom: 1.7vw;
+}
+
+h3.quietHeading {
+  text-transform: uppercase;
+  // font-size: $h6-font-size;
+  font-size: var(--wp--custom--typography--tiny);
+  margin-top: calc($spacer * 2.25);
+  font-weight: $font-weight-normal;
 }


### PR DESCRIPTION
– fix quietHeading size. Was being overwritten by h1 column clamp fix.
– tweak mobile nav sizing and remove border from offcanvas
– allow fancyLink to wrap