### PR TITLE
Responsive 08

### DIFF
--- a/src/scss/components/_latest_posts.scss
+++ b/src/scss/components/_latest_posts.scss
@@ -455,11 +455,11 @@ ul.chancellorFeaturePost {
     //   left: 42%;
     //   margin: 3rem 0 2rem 0;
     // }
-    &:last-child {
-      &:after {
-        content: none;
-      }
-    }
+    // &:last-child {
+    //   &:after {
+    //     content: none;
+    //   }
+    // }
     // &:before {
     //   content: 'READ MORE';
     //   font-size: var(--wp--custom--typography--tiny);
@@ -518,19 +518,19 @@ ul.chancellorFeaturePost {
     li {
       flex: 1 1 100%;
       text-align: left;
-      &:after {
-        content: '';
-        display: block;
-        height: 2px;
-        // border: 2px solid $utorange;
-        width: 8%;
-        // margin: 0 40%;
-        margin: 10px;
-        background: $utorange;
-        position: absolute;
-        left: 42%;
-        margin: 3rem 0 2rem 0;
-      }
+      // &:after {
+      //   content: '';
+      //   display: block;
+      //   height: 2px;
+      //   // border: 2px solid $utorange;
+      //   width: 8%;
+      //   // margin: 0 40%;
+      //   margin: 10px;
+      //   background: $utorange;
+      //   position: absolute;
+      //   left: 42%;
+      //   margin: 3rem 0 2rem 0;
+      // }
       @media screen and (min-width: 900px) {
         flex: 1 1 auto;
         border-right: 2px solid $utorange;

--- a/src/scss/components/_media-text.scss
+++ b/src/scss/components/_media-text.scss
@@ -4,10 +4,14 @@
   flex-direction: column;
   justify-content: center;
   .wp-block-media-text__media {
-    align-self: center !important;
+    align-self: flex-start !important;
+    max-width: 90%;
   }
   @include media-breakpoint-up(xxl) {
     display: grid !important;
     border: none;
+    .wp-block-media-text__media {
+      max-width: none;
+    }
   }
 }

--- a/src/scss/styles/_patterns.scss
+++ b/src/scss/styles/_patterns.scss
@@ -2,7 +2,7 @@
 
 .solid-news-triple {
   .has-light-grey-to-white-gradient-background {
-    transform: scale(2);
+    transform: scale(2.5);
 
     @media screen and (min-width: 1200px) {
       transform: scale(2.5);

--- a/src/scss/styles/_patterns.scss
+++ b/src/scss/styles/_patterns.scss
@@ -68,3 +68,11 @@
     }
   }
 }
+
+// Two up Gallery (large first) Forces image to overlap with orange bar on mobile. Grounds the image.
+.twoUp-gallery-lgsm figure:first-of-type {
+  margin-bottom: -5rem;
+  @media screen and (min-width: 700px) {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
remove separator from latest post on news (mobile)
tweak two up gallery – force first image to overlap orange bar (mobile)
tweak media-text (mobile) image size to improve visual flow
tweak background scale of gradient for news on home (mobile)